### PR TITLE
Move command to get undercloud IP to answers file

### DIFF
--- a/answers.yml.example
+++ b/answers.yml.example
@@ -68,6 +68,8 @@ instack_virt_setup_cmd: |
 
   instack-virt-setup
 
+instack_get_undercloud_ip: cat /var/lib/libvirt/dnsmasq/default.leases | grep $(tripleo get-vm-mac instack) | awk '{print $3;}' | head -n1
+
 instack_host_uc_http_port: 80
 instack_host_uc_ssh_port: 2200
 

--- a/roles/instack_uc_ip_and_forward/tasks/undercloud_ip.yml
+++ b/roles/instack_uc_ip_and_forward/tasks/undercloud_ip.yml
@@ -1,5 +1,5 @@
 - name: fetch undercloud VM IP address
-  shell: cat /var/lib/libvirt/dnsmasq/default.leases | grep $(tripleo get-vm-mac instack) | awk '{print $3;}' | head -n1
+  shell: "{{ instack_get_undercloud_ip }}"
   sudo_user: stack
   sudo: yes
   changed_when: false


### PR DESCRIPTION
Since more modern distributions of libvirt, such as the one included in
Fedora 23, no longer use the default.leases file. It's useful to move
the command that gets the undercloud's IP to the answers file, so it can
be edited if one uses a distribution that needs another method of doing
so.
