### PR TITLE
Get undercloud IP using virsh if no default.leases exists

### DIFF
--- a/roles/instack_uc_ip_and_forward/tasks/undercloud_ip.yml
+++ b/roles/instack_uc_ip_and_forward/tasks/undercloud_ip.yml
@@ -1,7 +1,10 @@
 - name: fetch undercloud VM IP address
-  shell: cat /var/lib/libvirt/dnsmasq/default.leases | grep $(tripleo get-vm-mac instack) | awk '{print $3;}' | head -n1
-  sudo_user: stack
-  sudo: yes
+  shell: |
+    if [ -e /var/lib/libvirt/dnsmasq/default.leases ]; then
+      cat /var/lib/libvirt/dnsmasq/default.leases | grep $(tripleo get-vm-mac instack) | awk '{print $3;}' | head -n1
+    else
+      virsh domifaddr instack | grep $(tripleo get-vm-mac instack) | awk '{print $4}' | sed 's/\/.*$//'
+    fi
   changed_when: false
   register: undercloud_ip
 


### PR DESCRIPTION
Since the usage of the default.leases file was deprecated from libvirt,
there is a need to have a the getting of the undercloud IP in such a way
that it works in both the new and the old way. So this commit addresses
that.

On the other hand, with the new method, for some reason it will not get
the IP if the stack user is used with sudo, in ansible. So this was
removed.
